### PR TITLE
MetronomeContext: dispatch `beat` and `loopstart` events

### DIFF
--- a/src/MetronomeContext/index.tsx
+++ b/src/MetronomeContext/index.tsx
@@ -108,10 +108,13 @@ export const MetronomeProvider: React.FC<Props> = (props) => {
       const isFirstBeat =
         (currentTick + 1) % (timeSignature.beatsPerMeasure * measureCount) === 0
       if (isFirstBeat) {
-        events.current.dispatchEvent(new Event('downbeat'))
+        events.current.dispatchEvent(new Event('loopstart'))
       }
       events.current.dispatchEvent(new Event('beat'))
-      playTone(audioContext.currentTime, isFirstBeat)
+      playTone(
+        audioContext.currentTime,
+        (currentTick + 1) % timeSignature.beatsPerMeasure === 0
+      )
       // Advance the beat number, wrap to zero when reaching end of measure
       setCurrentTick(
         (value) => (value + 1) % (timeSignature.beatsPerMeasure * measureCount)

--- a/src/hooks/useInterval.ts
+++ b/src/hooks/useInterval.ts
@@ -1,7 +1,7 @@
 // from: https://overreacted.io/making-setinterval-declarative-with-react-hooks/
 import { useEffect, useRef } from 'react'
 
-export function useInterval(callback: () => null, delay: number | null) {
+export function useInterval(callback: () => void, delay: number | null) {
   const savedCallback = useRef(callback)
 
   // Remember the latest callback.

--- a/src/icons/Record.tsx
+++ b/src/icons/Record.tsx
@@ -1,0 +1,17 @@
+type Props = {
+  fill: string
+}
+
+export const Record: React.FC<Props> = (props) => (
+  <svg
+    clipRule="evenodd"
+    fillRule="evenodd"
+    strokeLinejoin="round"
+    strokeMiterlimit="2"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    className="w-6"
+  >
+    <circle cx="12" cy="12" fillRule="nonzero" r="10" fill={props.fill} />
+  </svg>
+)


### PR DESCRIPTION
These events are necessary to synchronize start/stop events for recording