### PR TITLE
Set track recording buffer to exact length

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -50,7 +50,7 @@ A `Track` is a single mono or stereo audio buffer that contains audio data. A `T
   - shape: rectangle. Spans width of `Scene`
 - [x] Component can remove itself from scene https://github.com/ericyd/loop-supreme/pull/5
 - [x] Component has arm toggle button https://github.com/ericyd/loop-supreme/pull/8
-- [ ] audio data can be cleared from component without deleting it (to preserve track name)
+- [x] ~audio data can be cleared from component without deleting it (to preserve track name)~ just mute, and then re-record if desired
 - [x] deleting a track stops playback https://github.com/ericyd/loop-supreme/pull/13
 - [x] Component can record data from user device https://github.com/ericyd/loop-supreme/pull/8
 - [x] Component shows waveform of recorded audio https://github.com/ericyd/loop-supreme/pull/20
@@ -61,7 +61,7 @@ A `Track` is a single mono or stereo audio buffer that contains audio data. A `T
 - [x] recording accounts for audio latency https://github.com/ericyd/loop-supreme/pull/12
 - [x] Component gets confirmation before deleting track https://github.com/ericyd/loop-supreme/pull/15
 - [x] Fix Recording button styling/class (use Tailwind) https://github.com/ericyd/loop-supreme/pull/15
-- [ ] Ensure the audio buffer is always exactly as long as it needs to be to fill the loop
+- [x] Ensure the audio buffer is always exactly as long as it needs to be to fill the loop https://github.com/ericyd/loop-supreme/pull/23
 - [x] clean up functionality from recorder worklet that isn't being used (might want to hold off until I know how visualization will work) https://github.com/ericyd/loop-supreme/pull/20
 
 ## Saving audio
@@ -110,3 +110,12 @@ A `Track` is a single mono or stereo audio buffer that contains audio data. A `T
 - [ ] show alert if track latency cannot be detected, or if it seems wildly out of the norm (~100ms +/ 20ms ???). Consider adding a "custom latency" input option???
 - [x] remove useInterval hook (not used)
 - [x] investigate network calls to workers. https://github.com/ericyd/loop-supreme/pull/21
+
+## Design
+
+- [ ] Use brand colors for range inputs
+- [ ] Use brand colors for all colors!
+- [ ] Add dark mode capabilities
+- [ ] Add dark mode toggle button
+- [ ] allow Track to wrap (controls top, waveform bottom)
+- [ ] make Track controls slightly less wide

--- a/src/Start/index.tsx
+++ b/src/Start/index.tsx
@@ -48,7 +48,9 @@ export const Start: React.FC = () => {
         })
       )
     } catch (e) {
-      // TODO: better error handling
+      alert(
+        'big, terrible error occurred and there is no coming back from that 😿'
+      )
       logger.error(e, 'Error getting user media')
     }
 

--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -138,12 +138,12 @@ export const Track: React.FC<Props> = ({ id, onRemove, metronome }) => {
           // When in doubt... use dimensional analysis! 🙃
           //
           //  60 seconds    beats       60 seconds    minute
-          // --------  /  ----   ==  -------- x  ----      =>
+          // ———————————— ➗ —————   🟰  ——————————— 𝒙  ———————      =>
           //   minute      minute        minute       beats
           //
-          //   seconds    minutes  measures    beats     samples     samples
-          //  ------- x ----- x ------- x ------ x ------ == -------
-          //   minute     beat      loop      measure    second       loop
+          //   seconds    minutes   measures    beats     samples     samples
+          //  ————————— 𝒙 ———————— 𝒙 ———————— 𝒙 ———————— 𝒙 ————————— 🟰 ——————————
+          //   minute     beat      loop       measure    second       loop
           const targetRecordingLength =
             (60 / metronome.bpm) *
             metronome.measuresPerLoop *

--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -14,6 +14,7 @@ import type { ClockControllerMessage } from '../worklets/clock'
 import type {
   WaveformWorkerFrameMessage,
   WaveformWorkerMetronomeMessage,
+  WaveformWorkerResetMessage,
 } from '../worklets/waveform'
 import ArmTrackRecording from './ArmTrackRecording'
 import { getLatencySamples } from './get-latency-samples'
@@ -133,20 +134,42 @@ export const Track: React.FC<Props> = ({ id, onRemove, metronome }) => {
         }
 
         if (event.data.message === 'SHARE_RECORDING_BUFFER') {
-          const recordingLength = event.data.recordingLength
+          const fullRecordingLength = event.data.recordingLength
+          // When in doubt... use dimensional analysis! 🙃
+          //
+          //  60 seconds    beats       60 seconds    minute
+          // -------- ➗  ----    🟰  -------- 𝒙  ----   ➡
+          //   minute      minute        minute       beats
+          //
+          //   seconds    minutes  measures    beats     samples     samples
+          //  ------- 𝒙 ----- 𝒙 ------- 𝒙 ------ 𝒙 ------ 🟰 -------
+          //   minute     beat      loop      measure    second       loop
+          const targetRecordingLength =
+            (60 / metronome.bpm) *
+            metronome.measuresPerLoop *
+            metronome.timeSignature.beatsPerMeasure *
+            audioContext.sampleRate
+          logger.debug({
+            fullRecordingLength,
+            targetRecordingLength,
+            differenceInSamples: fullRecordingLength - targetRecordingLength,
+            differenceInSeconds:
+              (fullRecordingLength - targetRecordingLength) /
+              audioContext.sampleRate,
+          })
+
+          // create recording buffer with targetRecordingLength,
+          // to ensure it matches the loop length precisely.
           const recordingBuffer = audioContext.createBuffer(
             recordingProperties.numberOfChannels,
-            // TODO: I'm also not sure if constructing the audioBuffer from the "recordingLength" indicated from the worklet is the best way.
-            // Shouldn't we set it equal to the expected length of the recording based on the BPM and measure count?
-            // And if the recording is longer, we trim it; if it is shorter, we pad right with silence (which might be default behavior anyway)
-            recordingLength,
+            targetRecordingLength,
             audioContext.sampleRate
           )
 
           for (let i = 0; i < recordingProperties.numberOfChannels; i++) {
             // channelsData is an Array of Float32Arrays;
-            // each element of Array is a channel,
-            // which contains the raw samples for the audio data of that channel
+            // each element of Array is a channel, which contain
+            // the raw samples for the audio data of that channel
             recordingBuffer.copyToChannel(
               // copyToChannel accepts an optional 3rd argument, "startInChannel"[1] (or "bufferOffset" depending on your source).
               // which is described as
@@ -158,8 +181,7 @@ export const Track: React.FC<Props> = ({ id, onRemove, metronome }) => {
               // See `worklets/recorder` for the buffer offset
               // [1] https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer/copyToChannel
               // [2] https://jsfiddle.net/y7qL9wr4/7
-              // TODO: should this be sliced to a maximum of buffer size? Maybe a non-issue?
-              event.data.channelsData[i],
+              event.data.channelsData[i].slice(0, targetRecordingLength),
               i,
               0
             )
@@ -178,7 +200,13 @@ export const Track: React.FC<Props> = ({ id, onRemove, metronome }) => {
         }
       }
     },
-    [audioContext, waveformWorker]
+    [
+      audioContext,
+      waveformWorker,
+      metronome.bpm,
+      metronome.measuresPerLoop,
+      metronome.timeSignature.beatsPerMeasure,
+    ]
   )
 
   /**
@@ -262,6 +290,9 @@ export const Track: React.FC<Props> = ({ id, onRemove, metronome }) => {
         message: 'UPDATE_RECORDING_STATE',
         recording: true,
       })
+      waveformWorker.postMessage({
+        message: 'RESET_FRAMES',
+      } as WaveformWorkerResetMessage)
     }
   }
 

--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -138,11 +138,11 @@ export const Track: React.FC<Props> = ({ id, onRemove, metronome }) => {
           // When in doubt... use dimensional analysis! 🙃
           //
           //  60 seconds    beats       60 seconds    minute
-          // -------- ➗  ----    🟰  -------- 𝒙  ----   ➡
+          // --------  /  ----   ==  -------- x  ----      =>
           //   minute      minute        minute       beats
           //
           //   seconds    minutes  measures    beats     samples     samples
-          //  ------- 𝒙 ----- 𝒙 ------- 𝒙 ------ 𝒙 ------ 🟰 -------
+          //  ------- x ----- x ------- x ------ x ------ == -------
           //   minute     beat      loop      measure    second       loop
           const targetRecordingLength =
             (60 / metronome.bpm) *

--- a/src/icons/MetronomeIcon.tsx
+++ b/src/icons/MetronomeIcon.tsx
@@ -1,6 +1,4 @@
 // Metronome by ChangHoon Baek from <a href="https://thenounproject.com/icon/metronome-118052/" target="_blank" title="Metronome Icons">Noun Project</a>
-
-// TODO: need to clean this up
 export default function MetronomeIcon() {
   return (
     <svg version="1.1" viewBox="0 0 700 700" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Using the "recordingLength" from the recording processor does not typically equate to the length of the loop. It is often very close, but not precisely equal.

For one or two loops, the discrepancy is hard to detect, but over many loops the loop drifts substantially behind the beat and it becomes impossible to play along.

This fixes that issue