### PR TITLE
Keyboard bindings

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -73,10 +73,10 @@ A `Track` is a single mono or stereo audio buffer that contains audio data. A `T
 ## Keyboard
 
 - [ ] Keyboard shortcuts are added for most common actions
-  - `1`, `2`, `3`, etc select a track
-  - once a track is selected, `r` toggles "armed for recording", `m` toggles mute
-  - `t` is "tap tempo"
-  - `space` is play/pause
+  - [ ] `1`, `2`, `3`, etc select a track
+  - [ ] once a track is selected, `r` toggles "armed for recording", `m` toggles mute
+  - [ ] `t` is "tap tempo"
+  - [x] `space` is play/pause
 
 ## HTML
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -72,11 +72,11 @@ A `Track` is a single mono or stereo audio buffer that contains audio data. A `T
 
 ## Keyboard
 
-- [ ] Keyboard shortcuts are added for most common actions
-  - [ ] `1`, `2`, `3`, etc select a track
-  - [ ] once a track is selected, `r` toggles "armed for recording", `m` toggles mute
-  - [ ] `t` is "tap tempo"
+- [x] Keyboard shortcuts are added for most common actions https://github.com/ericyd/loop-supreme/pull/24
+  - [x] `1`, `2`, `3`, etc select a track
+  - [x] once a track is selected, `r` toggles "armed for recording", `m` toggles mute
   - [x] `space` is play/pause
+- [ ] add "tap tempo" functionlity and bind to `t` key
 
 ## HTML
 

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { AudioProvider } from '../AudioProvider'
+import { KeyboardProvider } from '../KeyboardProvider'
 import { Metronome } from '../Metronome'
 
 type Props = {
@@ -9,9 +10,11 @@ type Props = {
 
 function App(props: Props) {
   return (
-    <AudioProvider stream={props.stream} audioContext={props.audioContext}>
-      <Metronome />
-    </AudioProvider>
+    <KeyboardProvider>
+      <AudioProvider stream={props.stream} audioContext={props.audioContext}>
+        <Metronome />
+      </AudioProvider>
+    </KeyboardProvider>
   )
 }
 

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { AudioProvider } from '../AudioRouter'
+import { AudioProvider } from '../AudioProvider'
 import { Metronome } from '../Metronome'
 
 type Props = {

--- a/src/AudioProvider/index.tsx
+++ b/src/AudioProvider/index.tsx
@@ -1,9 +1,7 @@
 /**
- * AudioContext is already a global that is used extensively in this app.
- * Although this is a "React Context", it seemed more important to avoid naming collisions,
- * hence "AudioRouter"
- *
- * TODO: should this context be removed and values just be passed around as props?
+ * Exposes AudioContext (the web audio kind, not a React context)
+ * and a MediaStream globally.
+ * This could probably just be passed as props, but this is marginally more convenient.
  */
 import React, { createContext, useContext } from 'react'
 
@@ -24,11 +22,11 @@ export const AudioProvider: React.FC<Props> = ({ children, ...adapter }) => {
   return <AudioRouter.Provider value={adapter}>{children}</AudioRouter.Provider>
 }
 
-export function useAudioRouter() {
+export function useAudioContext() {
   const audioRouter = useContext(AudioRouter)
 
   if (audioRouter === null) {
-    throw new Error('useAudioRouter cannot be used outside of AudioProvider')
+    throw new Error('useAudioContext cannot be used outside of AudioProvider')
   }
 
   return audioRouter

--- a/src/ControlPanel/MetronomeControls.tsx
+++ b/src/ControlPanel/MetronomeControls.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect } from 'react'
 import PlayPause from '../icons/PlayPause'
 import { useKeyboard } from '../KeyboardProvider'
 import { VolumeControl } from './VolumeControl'
@@ -12,17 +13,23 @@ type MetronomeControlProps = {
 }
 export default function MetronomeControl(props: MetronomeControlProps) {
   const keyboard = useKeyboard()
-  const toggleMuted = () => {
+  const toggleMuted = useCallback(() => {
     props.setMuted((muted) => !muted)
-  }
-  keyboard.on('c', toggleMuted)
-  // kinda wish I could write "space" but I guess this is the way this works.
-  keyboard.on(' ', () => {
-    // Only toggle playing if another control element is not currently focused
-    if (!['SELECT', 'BUTTON'].includes(document.activeElement?.tagName ?? '')) {
-      props.togglePlaying()
-    }
-  })
+  }, [props])
+
+  useEffect(() => {
+    keyboard.on('c', 'Metronome', toggleMuted)
+    // kinda wish I could write "space" but I guess this is the way this works.
+    keyboard.on(' ', 'Metronome', (e) => {
+      // Only toggle playing if another control element is not currently focused
+      if (
+        !['SELECT', 'BUTTON'].includes(document.activeElement?.tagName ?? '')
+      ) {
+        props.togglePlaying()
+        e.preventDefault()
+      }
+    })
+  }, [keyboard, props, toggleMuted])
 
   return (
     <div className="flex items-start content-center mb-2 mr-2">

--- a/src/ControlPanel/MetronomeControls.tsx
+++ b/src/ControlPanel/MetronomeControls.tsx
@@ -15,7 +15,7 @@ export default function MetronomeControl(props: MetronomeControlProps) {
   const toggleMuted = () => {
     props.setMuted((muted) => !muted)
   }
-  keyboard.on('m', toggleMuted)
+  keyboard.on('c', toggleMuted)
   // kinda wish I could write "space" but I guess this is the way this works.
   keyboard.on(' ', () => {
     // Only toggle playing if another control element is not currently focused

--- a/src/ControlPanel/MetronomeControls.tsx
+++ b/src/ControlPanel/MetronomeControls.tsx
@@ -17,7 +17,12 @@ export default function MetronomeControl(props: MetronomeControlProps) {
   }
   keyboard.on('m', toggleMuted)
   // kinda wish I could write "space" but I guess this is the way this works.
-  keyboard.on(' ', props.togglePlaying)
+  keyboard.on(' ', () => {
+    // Only toggle playing if another control element is not currently focused
+    if (!['SELECT', 'BUTTON'].includes(document.activeElement?.tagName ?? '')) {
+      props.togglePlaying()
+    }
+  })
 
   return (
     <div className="flex items-start content-center mb-2 mr-2">

--- a/src/ControlPanel/MetronomeControls.tsx
+++ b/src/ControlPanel/MetronomeControls.tsx
@@ -1,4 +1,5 @@
 import PlayPause from '../icons/PlayPause'
+import { useKeyboard } from '../KeyboardProvider'
 import { VolumeControl } from './VolumeControl'
 
 type MetronomeControlProps = {
@@ -10,9 +11,13 @@ type MetronomeControlProps = {
   gain: number
 }
 export default function MetronomeControl(props: MetronomeControlProps) {
+  const keyboard = useKeyboard()
   const toggleMuted = () => {
     props.setMuted((muted) => !muted)
   }
+  keyboard.on('m', toggleMuted)
+  // kinda wish I could write "space" but I guess this is the way this works.
+  keyboard.on(' ', props.togglePlaying)
 
   return (
     <div className="flex items-start content-center mb-2 mr-2">

--- a/src/KeyboardProvider/index.tsx
+++ b/src/KeyboardProvider/index.tsx
@@ -1,0 +1,70 @@
+/**
+ * Exposes a context that can be used to bind keyboard events throughout the app.
+ * Keydown/Keyup listeners are easy to add, but the syntax is kind of annoying
+ * because the callback has to check for the right key.
+ * This is a more convenient wrapper for `window.addEventListener('keydown', callback).
+ * Perhaps this doesn't need to be a context at all, and can just be an exported function
+ * that wraps `window.addEventListener` -- we'll see!
+ *
+ * (intended) Usage:
+ *
+ * function MyComponent() {
+ *   const keyboard = useKeyboard()
+ *
+ *   function myFunction() {
+ *     // do something
+ *   }
+ *
+ *   keyboard.on('a', myFunction)
+ * }
+ */
+import React, { createContext, useContext, useEffect } from 'react'
+import { logger } from '../util/logger'
+
+type KeyboardController = {
+  on(key: string, callback: () => void): void
+}
+
+const KeyboardContext = createContext<KeyboardController | null>(null)
+
+type Props = {
+  children: React.ReactNode
+}
+
+export const KeyboardProvider: React.FC<Props> = ({ children, ...adapter }) => {
+  // map of keys to callbacks
+  const callbackMap: Record<string, () => void> = {}
+
+  useEffect(() => {
+    const keydownCallback = (e: KeyboardEvent) => {
+      logger.debug({ key: e.key, meta: e.metaKey, shift: e.shiftKey })
+      callbackMap[e.key]?.()
+    }
+    window.addEventListener('keydown', keydownCallback)
+    return () => {
+      window.removeEventListener('keydown', keydownCallback)
+    }
+  }, [])
+
+  const controller = {
+    on: (key: string, callback: () => void) => {
+      callbackMap[key] = callback
+    },
+  }
+
+  return (
+    <KeyboardContext.Provider value={controller}>
+      {children}
+    </KeyboardContext.Provider>
+  )
+}
+
+export function useKeyboard() {
+  const keyboard = useContext(KeyboardContext)
+
+  if (keyboard === null) {
+    throw new Error('useKeyboard cannot be used outside of KeyboardProvider')
+  }
+
+  return keyboard
+}

--- a/src/Metronome/KeyboardBindings.tsx
+++ b/src/Metronome/KeyboardBindings.tsx
@@ -1,3 +1,20 @@
+/**
+ * This is a simple display input,
+ * to inform users how to use keyboard bindings.
+ */
+
+const globalKeyBindings = {
+  space: 'Play / pause',
+  c: 'Mute click track',
+  '0-9': 'Select track',
+}
+
+const trackKeyBindings = {
+  r: 'Arm for recording',
+  m: 'Mute track',
+  i: 'Monitor input',
+}
+
 export default function KeyboardBindings() {
   return (
     <div>
@@ -10,22 +27,12 @@ export default function KeyboardBindings() {
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td className="w-32">Space</td>
-            <td>Play / pause</td>
-          </tr>
-
-          <tr>
-            <td className="w-32">c</td>
-            <td>
-              Mute <strong>c</strong>lick track
-            </td>
-          </tr>
-
-          <tr>
-            <td className="w-32">0-9</td>
-            <td>Select track</td>
-          </tr>
+          {Object.entries(globalKeyBindings).map(([key, action]) => (
+            <tr>
+              <td className="w-32">{key}</td>
+              <td>{action}</td>
+            </tr>
+          ))}
 
           <tr>
             <td colSpan={2}>
@@ -33,26 +40,12 @@ export default function KeyboardBindings() {
             </td>
           </tr>
 
-          <tr>
-            <td className="w-32">r</td>
-            <td>
-              Arm <strong>r</strong>ecording
-            </td>
-          </tr>
-
-          <tr>
-            <td className="w-32">i</td>
-            <td>
-              Monitor <strong>i</strong>nput
-            </td>
-          </tr>
-
-          <tr>
-            <td className="w-32">m</td>
-            <td>
-              <strong>M</strong>ute track
-            </td>
-          </tr>
+          {Object.entries(trackKeyBindings).map(([key, action]) => (
+            <tr>
+              <td className="w-32">{key}</td>
+              <td>{action}</td>
+            </tr>
+          ))}
         </tbody>
       </table>
     </div>

--- a/src/Metronome/KeyboardBindings.tsx
+++ b/src/Metronome/KeyboardBindings.tsx
@@ -16,13 +16,42 @@ export default function KeyboardBindings() {
           </tr>
 
           <tr>
-            <td className="w-32">m</td>
-            <td>Mute metronome</td>
+            <td className="w-32">c</td>
+            <td>
+              Mute <strong>c</strong>lick track
+            </td>
           </tr>
 
           <tr>
             <td className="w-32">0-9</td>
             <td>Select track</td>
+          </tr>
+
+          <tr>
+            <td colSpan={2}>
+              <em>After selecting track</em>
+            </td>
+          </tr>
+
+          <tr>
+            <td className="w-32">r</td>
+            <td>
+              Arm <strong>r</strong>ecording
+            </td>
+          </tr>
+
+          <tr>
+            <td className="w-32">i</td>
+            <td>
+              Monitor <strong>i</strong>nput
+            </td>
+          </tr>
+
+          <tr>
+            <td className="w-32">m</td>
+            <td>
+              <strong>M</strong>ute track
+            </td>
           </tr>
         </tbody>
       </table>

--- a/src/Metronome/KeyboardBindings.tsx
+++ b/src/Metronome/KeyboardBindings.tsx
@@ -1,0 +1,31 @@
+export default function KeyboardBindings() {
+  return (
+    <div>
+      <h2 className="text-xl mb-8 mt-16">Keyboard controls</h2>
+      <table className="">
+        <thead>
+          <tr>
+            <th className="text-left">Key</th>
+            <th className="text-left">Binding</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="w-32">Space</td>
+            <td>Play / pause</td>
+          </tr>
+
+          <tr>
+            <td className="w-32">m</td>
+            <td>Mute metronome</td>
+          </tr>
+
+          <tr>
+            <td className="w-32">0-9</td>
+            <td>Select track</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/Metronome/index.tsx
+++ b/src/Metronome/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useAudioRouter } from '../AudioRouter'
+import { useAudioContext } from '../AudioProvider'
 import { ControlPanel } from '../ControlPanel'
 import { Scene } from '../Scene'
 import type { ClockControllerMessage } from '../worklets/clock'
@@ -39,7 +39,7 @@ type Props = {
 }
 
 export const Metronome: React.FC<Props> = () => {
-  const { audioContext } = useAudioRouter()
+  const { audioContext } = useAudioContext()
   const [currentTick, setCurrentTick] = useState(-1)
   const [bpm, setBpm] = useState(120)
   const [timeSignature, setTimeSignature] = useState<TimeSignature>({

--- a/src/Metronome/index.tsx
+++ b/src/Metronome/index.tsx
@@ -3,6 +3,7 @@ import { useAudioContext } from '../AudioProvider'
 import { ControlPanel } from '../ControlPanel'
 import { Scene } from '../Scene'
 import type { ClockControllerMessage } from '../worklets/clock'
+import KeyboardBindings from './KeyboardBindings'
 import { decayingSine } from './waveforms'
 
 export type TimeSignature = {
@@ -187,6 +188,7 @@ export const Metronome: React.FC<Props> = () => {
     <>
       <ControlPanel metronome={reader} metronomeWriter={writer} />
       <Scene metronome={reader} />
+      <KeyboardBindings />
     </>
   )
 }

--- a/src/Scene/index.tsx
+++ b/src/Scene/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import ButtonBase from '../ButtonBase'
 import { Plus } from '../icons/Plus'
 import { useKeyboard } from '../KeyboardProvider'
@@ -11,7 +11,6 @@ type Props = {
 
 export const Scene: React.FC<Props> = ({ metronome }) => {
   const keyboard = useKeyboard()
-  keyboard.on('a', handleAddTrack)
   const [tracks, setTracks] = useState([{ id: 1, selected: false }])
 
   function handleAddTrack() {
@@ -50,13 +49,18 @@ export const Scene: React.FC<Props> = ({ metronome }) => {
     }
   }
 
+  /**
+   * Attach keyboard events
+   */
   useEffect(() => {
+    keyboard.on('a', 'Scene', handleAddTrack)
     for (let i = 0; i < 10; i++) {
-      keyboard.on(String(i), setSelected(i))
+      keyboard.on(String(i), `Scene ${i}`, setSelected(i))
     }
     return () => {
+      keyboard.off('a', 'Scene')
       for (let i = 0; i < 10; i++) {
-        keyboard.off(String(i), setSelected(i))
+        keyboard.off(String(i), `Scene ${i}`)
       }
     }
   }, [keyboard])

--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -1,3 +1,11 @@
+/**
+ * Tracks are where the magic happens!
+ * A Track encapsulates a single audio recording stream,
+ * either mono or stereo.
+ * Tracks contain controls for recording, monitoring, muting, etc.
+ * After recording is complete, the audio buffer loops automatically,
+ * a nice feature of the Web Audio API.
+ */
 import React, {
   ChangeEventHandler,
   useCallback,
@@ -26,6 +34,7 @@ type Props = {
   id: number
   onRemove(): void
   metronome: MetronomeReader
+  selected: boolean
 }
 
 type RecordingProperties = {
@@ -60,7 +69,12 @@ type RecordingMessage =
   | ShareRecordingBufferMessage
   | UpdateWaveformMessage
 
-export const Track: React.FC<Props> = ({ id, onRemove, metronome }) => {
+export const Track: React.FC<Props> = ({
+  id,
+  onRemove,
+  metronome,
+  selected,
+}) => {
   const { audioContext, stream } = useAudioContext()
   const [title, setTitle] = useState(`Track ${id}`)
   const [armed, setArmed] = useState(false)
@@ -279,46 +293,53 @@ export const Track: React.FC<Props> = ({ id, onRemove, metronome }) => {
   })
 
   return (
-    <div className="flex items-stretch content-center mb-2 pb-2 border-b border-solid border-zinc-400">
-      {/* Controls */}
-      <div className="flex flex-col">
-        {/* Title, Record, Monitor */}
-        <div className="flex items-stretch content-center">
-          <input
-            value={title}
-            onChange={handleChangeTitle}
-            className="pl-2 -pr-2 flex-initial mr-2 rounded-full"
-          />
-          <ArmTrackRecording
-            toggleArmRecording={toggleArmRecording}
-            armed={armed}
-            recording={recording}
-          />
-          <MonitorInput
-            toggleMonitoring={toggleMonitoring}
-            monitoring={monitoring}
-          />
-          <Mute onClick={toggleMuted} muted={muted} />
+    <>
+      <div
+        className={`flex items-stretch content-center p-2 rounded-md
+                  ${selected ? 'shadow-[0_0_0_5px_rgba(82,142,176,1)]' : ''}`}
+      >
+        {/* Controls */}
+        <div className="flex flex-col">
+          {/* Title, Record, Monitor */}
+          <div className="flex items-stretch content-center">
+            <input
+              value={title}
+              onChange={handleChangeTitle}
+              className="pl-2 -pr-2 flex-initial mr-2 rounded-full"
+            />
+            <ArmTrackRecording
+              toggleArmRecording={toggleArmRecording}
+              armed={armed}
+              recording={recording}
+            />
+            <MonitorInput
+              toggleMonitoring={toggleMonitoring}
+              monitoring={monitoring}
+            />
+            <Mute onClick={toggleMuted} muted={muted} />
+          </div>
+
+          {/* Volume */}
+          <div className="w-full">
+            <VolumeControl gain={gain} onChange={setGain} />
+          </div>
+
+          {/* Remove */}
+          <div>
+            <RemoveTrack onRemove={onRemove} />
+          </div>
         </div>
 
-        {/* Volume */}
-        <div className="w-full">
-          <VolumeControl gain={gain} onChange={setGain} />
-        </div>
-
-        {/* Remove */}
-        <div>
-          <RemoveTrack onRemove={onRemove} />
+        {/* Waveform */}
+        <div className="grow self-stretch">
+          <Waveform
+            worker={waveformWorker}
+            sampleRate={audioContext.sampleRate}
+          />
         </div>
       </div>
-
-      {/* Waveform */}
-      <div className="grow self-stretch">
-        <Waveform
-          worker={waveformWorker}
-          sampleRate={audioContext.sampleRate}
-        />
-      </div>
-    </div>
+      {/* divider */}
+      <div className="border-b border-solid border-zinc-400 w-full h-2 mb-2" />
+    </>
   )
 }

--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -6,7 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { useAudioRouter } from '../AudioRouter'
+import { useAudioContext } from '../AudioProvider'
 import { MetronomeReader } from '../Metronome'
 import { logger } from '../util/logger'
 import { VolumeControl } from './VolumeControl'
@@ -61,7 +61,7 @@ type RecordingMessage =
   | UpdateWaveformMessage
 
 export const Track: React.FC<Props> = ({ id, onRemove, metronome }) => {
-  const { audioContext, stream } = useAudioRouter()
+  const { audioContext, stream } = useAudioContext()
   const [title, setTitle] = useState(`Track ${id}`)
   const [armed, setArmed] = useState(false)
   const toggleArmRecording = () => setArmed((value) => !value)


### PR DESCRIPTION
- Add "KeyboardProvider". This context exposes a simple way to bind `keydown` events on specific keys to a callback. A context is useful here because it allows the app to use a single callback, and delegate the event based on which key is pressed.
- Bind keyboard to following events
    - space (play/pause)
    - `c` for muting the click track
    - `0-9` for selecting a track
    - `r` for arming recording on a specific track
    - `m` for muting a specific track
    - `i` for monitoring input on a specific track