### PR TITLE
Loop start correction

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -91,6 +91,7 @@ A `Track` is a single mono or stereo audio buffer that contains audio data. A `T
 
 ## Misc
 
+- [ ] `Bug`: using keyboard shortcuts is causing weird recording artifacts... 😭
 - [x] clean up "start" button/view
 - [x] Allow user to change inputs https://github.com/ericyd/loop-supreme/pull/25
 - [ ] clean up TODOs

--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -332,16 +332,19 @@ export const Track: React.FC<Props> = ({
     // this is almost certainly imperfect, but at least it will **appear** to be accurate.
     // AudioSourceNodes, including AudioBufferSourceNodes, can only be started once, therefore
     // need to stop, create new, and start again
-    // TODO: see if there is any way to soften the stop, so it doesn't sound so clippy
     // TODO: allow clearing via re-recording. Maybe set up a second buffer?
-    // HUGE BUG: using keyboard short cuts is causing weird recording artifacts... 😭
     if (bufferSource.current?.buffer) {
-      // TODO: maybe I don't even need to stop?
-      // bufferSource.current.stop()
       bufferSource.current = new AudioBufferSourceNode(audioContext, {
         buffer: bufferSource.current.buffer,
       })
       bufferSource.current.connect(gainNode.current)
+      // ramp up to desired gain quickly to avoid clips at the beginning of the loop
+      gainNode.current.gain.value = 0.0
+      gainNode.current.gain.setTargetAtTime(
+        gain,
+        audioContext.currentTime,
+        0.02
+      )
       bufferSource.current.start()
     }
   }

--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -101,6 +101,7 @@ export const Track: React.FC<Props> = ({
     () => new Worker(new URL('../worklets/export', import.meta.url)),
     []
   )
+  const downloadLinkRef = useRef<HTMLAnchorElement>(null)
 
   /**
    * Set up track gain.
@@ -408,13 +409,12 @@ export const Track: React.FC<Props> = ({
 
     function handleWavBlob(event: MessageEvent<WavBlobControllerEvent>) {
       logger.debug(`Handling WAV message for track ${title}, ID ${id}`)
-      if (event.data.message === 'WAV_BLOB') {
-        let file = new File([event.data.blob], `${title}.wav`, {
-          type: 'audio/wav',
-        })
-        let exportUrl = URL.createObjectURL(file)
-        window.open(exportUrl)
-        window.URL.revokeObjectURL(exportUrl)
+      if (event.data.message === 'WAV_BLOB' && downloadLinkRef.current) {
+        const url = window.URL.createObjectURL(event.data.blob)
+        downloadLinkRef.current.href = url
+        downloadLinkRef.current.download = `${title.replace(/\s/g, '-')}.wav`
+        downloadLinkRef.current.click()
+        window.URL.revokeObjectURL(url)
       }
     }
 
@@ -476,6 +476,14 @@ export const Track: React.FC<Props> = ({
           />
         </div>
       </div>
+      {/* Download element - inspired by this SO answer https://stackoverflow.com/a/19328891/3991555 */}
+      <a
+        ref={downloadLinkRef}
+        href="https://test.example.com"
+        className="hidden"
+      >
+        Download
+      </a>
       {/* divider */}
       <div className="border-b border-solid border-zinc-400 w-full h-2 mb-2" />
     </>

--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -336,30 +336,8 @@ export const Track: React.FC<Props> = ({
     // TODO: allow clearing via re-recording. Maybe set up a second buffer?
     // HUGE BUG: using keyboard short cuts is causing weird recording artifacts... 😭
     if (bufferSource.current?.buffer) {
-      bufferSource.current.stop()
-
-      // maximal version
-      // const buffer = bufferSource.current.buffer
-
-      // const recordingBuffer = audioContext.createBuffer(
-      //   buffer.numberOfChannels,
-      //   buffer.length,
-      //   audioContext.sampleRate
-      // )
-
-      // for (let i = 0; i < buffer.numberOfChannels; i++) {
-      //   recordingBuffer.copyToChannel(buffer.getChannelData(i), i, 0)
-      // }
-
-      // bufferSource.current = new AudioBufferSourceNode(audioContext, {
-      //   buffer: recordingBuffer,
-      // })
-
-      // gainNode.current.connect(audioContext.destination)
-      // bufferSource.current.connect(gainNode.current)
-      // bufferSource.current.start()
-
-      // minimal version
+      // TODO: maybe I don't even need to stop?
+      // bufferSource.current.stop()
       bufferSource.current = new AudioBufferSourceNode(audioContext, {
         buffer: bufferSource.current.buffer,
       })


### PR DESCRIPTION
- Fix loop start by simply starting a new loop on every "loopStart" event, rather than relying on the `loop` property. This feels a little strange, but ultimately the worker clock is the heartbeat, so synchronizing with that makes sense
- Fix file download/export in Chrome