### PR TITLE
Fix recording settings (define constraints)

### DIFF
--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -4,8 +4,9 @@ import { useKeybindings } from '../hooks/use-keybindings'
 import { KeyboardBindingsList } from './KeyboardBindingsList'
 
 type Props = {
-  stream: MediaStream
+  defaultDeviceId: string
   audioContext: AudioContext
+  devices: MediaDeviceInfo[]
 }
 
 function App(props: Props) {

--- a/src/AudioProvider/index.tsx
+++ b/src/AudioProvider/index.tsx
@@ -7,14 +7,16 @@ import React, { createContext, useContext } from 'react'
 
 type AudioAdapter = {
   audioContext: AudioContext
-  stream: MediaStream
+  defaultDeviceId: string
+  devices: MediaDeviceInfo[]
 }
 
 const AudioRouter = createContext<AudioAdapter | null>(null)
 
 type Props = {
-  stream: MediaStream
+  defaultDeviceId: string
   audioContext: AudioContext
+  devices: MediaDeviceInfo[]
   children: React.ReactNode
 }
 

--- a/src/Track/controls/SelectInput.tsx
+++ b/src/Track/controls/SelectInput.tsx
@@ -1,44 +1,57 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { logger } from '../../util/logger'
 import { deviceIdFromStream } from '../../util/device-id-from-stream'
+import { useAudioContext } from '../../AudioProvider'
 
 type Props = {
-  defaultDeviceId: string
   setStream(stream: MediaStream): void
 }
 
-export function SelectInput(props: Props) {
-  const [inputs, setInputs] = useState<MediaDeviceInfo[]>([])
-  const [selected, setSelected] = useState(props.defaultDeviceId)
+export function SelectInput({ setStream }: Props) {
+  const { devices, defaultDeviceId } = useAudioContext()
+  const [selected, setSelected] = useState(defaultDeviceId)
 
-  useEffect(() => {
-    async function getInputs() {
-      const devices = await navigator.mediaDevices.enumerateDevices()
-      const audioInputs = devices.filter(
-        (device) => device.kind === 'audioinput'
-      )
-      logger.debug({ audioInputs })
-      setInputs(audioInputs)
-    }
+  const setStreamByDeviceId = useCallback(
+    async (id: string) => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            deviceId: id,
 
-    getInputs()
-  }, [])
+            // for some reason,
+            // having these defined makes a HUGE difference in the recording quality.
+            // Without these defined, the audio will pulse in and out, but with these defined, it sounds great
+            echoCancellation: false,
+            autoGainControl: false,
+            noiseSuppression: false,
+            suppressLocalAudioPlayback: false,
+            latency: 0,
+          },
+          video: false,
+        })
+        setStream(stream)
+        setSelected(deviceIdFromStream(stream) ?? '')
+      } catch (e) {
+        alert('oh no, you broke it 😿')
+        logger.error({
+          e,
+          id,
+          message: 'Failed to create stream from selected device',
+        })
+      }
+    },
+    [setStream]
+  )
 
   const handleChange: React.ChangeEventHandler<HTMLSelectElement> = async (
     event
   ) => {
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({
-        audio: { deviceId: event.target.value },
-        video: false,
-      })
-      props.setStream(stream)
-      setSelected(deviceIdFromStream(stream) ?? '')
-    } catch (e) {
-      alert('oh no, you broke it 😿')
-      console.error(e)
-    }
+    return setStreamByDeviceId(event.target.value)
   }
+
+  useEffect(() => {
+    setStreamByDeviceId(defaultDeviceId)
+  }, [setStreamByDeviceId, defaultDeviceId])
 
   return (
     <select
@@ -46,10 +59,10 @@ export function SelectInput(props: Props) {
       onChange={handleChange}
       value={selected}
     >
-      {inputs.map((input) => (
-        <option key={JSON.stringify(input)} value={input.deviceId}>
+      {devices.map((device) => (
+        <option key={JSON.stringify(device)} value={device.deviceId}>
           {/* Chrome appends a weird hex ID to some inputs */}
-          {input.label.replace(/\([a-z0-9]+:[a-z0-9]+\)/, '')}
+          {device.label.replace(/\([a-z0-9]+:[a-z0-9]+\)/, '')}
         </option>
       ))}
     </select>

--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -30,7 +30,6 @@ import { Mute } from './controls/Mute'
 import { RemoveTrack } from './controls/RemoveTrack'
 import { Waveform } from './Waveform'
 import { SelectInput } from './controls/SelectInput'
-import { deviceIdFromStream } from '../util/device-id-from-stream'
 import type {
   ExportWavWorkerEvent,
   WavBlobControllerEvent,
@@ -84,9 +83,9 @@ export const Track: React.FC<Props> = ({
   selected,
   exportTarget,
 }) => {
-  const { audioContext, stream: defaultStream } = useAudioContext()
-  const [stream, setStream] = useState(defaultStream)
-  const defaultDeviceId = deviceIdFromStream(defaultStream) ?? ''
+  const { audioContext } = useAudioContext()
+  // stream is initialized in SelectInput
+  const [stream, setStream] = useState<MediaStream | null>(null)
 
   // title is mostly display-only, but also defines the file name when downloading files
   const [title, setTitle] = useState(`Track ${id}`)
@@ -229,6 +228,9 @@ export const Track: React.FC<Props> = ({
    * Initialize the recorder worklet, and connect the audio graph for eventual playback.
    */
   useEffect(() => {
+    if (!stream) {
+      return
+    }
     const mediaSource = audioContext.createMediaStreamSource(stream)
     const recordingProperties: RecordingProperties = {
       numberOfChannels: mediaSource.channelCount,
@@ -424,10 +426,7 @@ export const Track: React.FC<Props> = ({
           {/* Remove */}
           <div className="flex items-stretch content-center justify-between">
             <RemoveTrack onRemove={onRemove} />
-            <SelectInput
-              setStream={setStream}
-              defaultDeviceId={defaultDeviceId}
-            />
+            <SelectInput setStream={setStream} />
           </div>
         </div>
 


### PR DESCRIPTION
- Define constraints on audio when getting user media. This doesn't make sense why this is required, but it makes the recording actually work on my audio interface, whereas previously the audio would fade in and out inexplicably.
- Create the track's stream on track mount, rather than on Start. This makes properties a bit easier to pass around, and prevents re-using the same stream for multiple tracks. I'm not sure this is illegal, but this felt like a better approach