### PR TITLE
Metronome garbage cleanup

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -30,6 +30,7 @@ The `Metronome` is the heart of the app. The BPM, measure, current tick, and tim
 - [x] Metronome must initialize as "stopped", and can be "started" by user input https://github.com/ericyd/loop-supreme/pull/4
 - [x] Metronome can be muted, while still running https://github.com/ericyd/loop-supreme/pull/11
 - [x] ~move "playing" state into MetronomeControls; there is no obvious need for it to live in Metronome~ irrelevant after https://github.com/ericyd/loop-supreme/pull/28
+- [ ] allow changing tempo by typing value into an input
 
 ## Scene
 
@@ -92,7 +93,7 @@ A `Track` is a single mono or stereo audio buffer that contains audio data. A `T
 
 ## Misc
 
-- [ ] `Bug`: using keyboard shortcuts is causing weird recording artifacts... 😭
+- [x] `Bug`: using keyboard shortcuts is causing weird recording artifacts... 😭 https://github.com/ericyd/loop-supreme/pull/30
 - [x] clean up "start" button/view
 - [x] Allow user to change inputs https://github.com/ericyd/loop-supreme/pull/25
 - [ ] clean up TODOs

--- a/src/Start/index.tsx
+++ b/src/Start/index.tsx
@@ -95,11 +95,9 @@ export const Start: React.FC = () => {
   }
 
   async function handleClick() {
-    await Promise.all([
-      grantDevicePermission(),
-      enumerateDevices(),
-      initializeAudioContext(),
-    ])
+    await grantDevicePermission()
+    await enumerateDevices()
+    await initializeAudioContext()
   }
 
   return defaultDeviceId && audioContext && devices?.length ? (


### PR DESCRIPTION
- disconnect GainNodes that are created in Metronome, if the audioContext changes
- do not create a GainNode inside useRef; create it in useEffect
- disconnect `AudioBufferSourceNode` on each tick, if it exists