### PR TITLE
Update buffer creation

### DIFF
--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -244,7 +244,7 @@ export const Track: React.FC<Props> = ({
                 0,
                 recordingProperties.latencySamples
               ),
-              firstPart.length
+              firstPart.byteLength // length vs byteLength...
             )
             // channelsData is an Array of Float32Arrays;
             // each element of Array is a channel, which contain

--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -363,18 +363,9 @@ export const Track: React.FC<Props> = ({
         buffer: bufferSource.current.buffer,
       })
       bufferSource.current.connect(gainNode.current)
-      // ramp up to desired gain quickly to avoid clips at the beginning of the loop
-      gainNode.current.gain.value = 0.0
-      if (!muted) {
-        gainNode.current.gain.setTargetAtTime(
-          gain,
-          audioContext.currentTime,
-          0.005
-        )
-      }
       bufferSource.current.start()
     }
-  }, [armed, audioContext, gain, muted, recording, waveformWorker])
+  }, [armed, audioContext, recording, waveformWorker])
 
   useEffect(() => {
     function delegateClockMessage(event: MessageEvent<ClockControllerMessage>) {

--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -234,21 +234,17 @@ export const Track: React.FC<Props> = ({
             // To account for that latency, we shift the input data left by `latencySamples` samples,
             // and add the remainder on to the end of the array. In theory, this will preserve transients that occur right at the beginning of the loop
             const buffer = new Float32Array(targetRecordingLength)
+            // why does half sound good? No idea!!!
+            const latencySamples = recordingProperties.latencySamples / 2
             const firstPart = event.data.channelsData[i].slice(
-              recordingProperties.latencySamples,
+              latencySamples,
               targetRecordingLength
             )
             buffer.set(firstPart)
             buffer.set(
-              event.data.channelsData[i].slice(
-                0,
-                recordingProperties.latencySamples
-              ),
-              firstPart.byteLength // length vs byteLength...
+              event.data.channelsData[i].slice(0, latencySamples),
+              firstPart.length // length vs byteLength... ?
             )
-            // channelsData is an Array of Float32Arrays;
-            // each element of Array is a channel, which contain
-            // the raw samples for the audio data of that channel
             recordingBuffer.copyToChannel(
               // copyToChannel accepts an optional 3rd argument, "startInChannel"[1] (or "bufferOffset" depending on your source).
               // which is described as

--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -229,13 +229,14 @@ export const Track: React.FC<Props> = ({
             audioContext.sampleRate
           )
 
+          // why does half sound good? No idea!!!
+          const latencySamples = recordingProperties.latencySamples / 2
+
           for (let i = 0; i < recordingProperties.numberOfChannels; i++) {
             // The input hardware will have some recording latency.
             // To account for that latency, we shift the input data left by `latencySamples` samples,
             // and add the remainder on to the end of the array. In theory, this will preserve transients that occur right at the beginning of the loop
             const buffer = new Float32Array(targetRecordingLength)
-            // why does half sound good? No idea!!!
-            const latencySamples = recordingProperties.latencySamples / 2
             const firstPart = event.data.channelsData[i].slice(
               latencySamples,
               targetRecordingLength
@@ -253,7 +254,6 @@ export const Track: React.FC<Props> = ({
               // I believe the intended use case is to synchronize audio playback with other media (e.g. video).
               // However, in this case, we are trying to align recorded audio with the start of the loop.
               // In this case we need to **subtract** audio from the buffer, in accordance with the latency of the recording device.
-              // See `worklets/recorder` for the buffer offset
               // [1] https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer/copyToChannel
               // [2] https://jsfiddle.net/y7qL9wr4/7
               buffer,

--- a/src/workers/export.ts
+++ b/src/workers/export.ts
@@ -7,6 +7,8 @@
  * was converted to a Worker so this could be done off the main thread.
  */
 
+import { logger } from '../util/logger'
+
 function writeStringToArray(
   value: string,
   targetArray: Uint8Array,

--- a/src/workers/export.ts
+++ b/src/workers/export.ts
@@ -7,8 +7,6 @@
  * was converted to a Worker so this could be done off the main thread.
  */
 
-import { logger } from '../util/logger'
-
 function writeStringToArray(
   value: string,
   targetArray: Uint8Array,

--- a/src/workers/recorder.js
+++ b/src/workers/recorder.js
@@ -169,16 +169,8 @@ class RecordingProcessor extends AudioWorkletProcessor {
 
           // Copy data to recording buffer.
           if (this.recording) {
-            this.channelsData[channel][
-              // The input hardware will have some recording latency.
-              // To account for that latency, we shift the input data left by `latencySamples` samples.
-              // Alternatives:
-              //    1. This could be done when copying the buffer to the AudioBuffer channel.
-              //       However, to keep everything synchronized (including visuals eventually),
-              //       it made sense for the recording processor to automatically account for input latency.
-              // See Track.tsx for latency determination
-              Math.max(sample + this.recordedSamples - this.latencySamples, 0)
-            ] = currentSample
+            this.channelsData[channel][sample + this.recordedSamples] =
+              currentSample
 
             // Sum values for visualizer
             this.gainSum += currentSample


### PR DESCRIPTION
- use half of the recording latency as the buffer offset. Not sure why half the reported latency sounds good but it seems to!
- instead of just dropping the part of the audio that would normally be trimmed due to latency, stick it on the end of the buffer. In theory, if the first part of the buffer contained a transient, this might allow the transient to hit at the very end of the loop and "connect" back to the beginning. 🤷🏻 It's a little bit of a shot in the dark, but it didn't seem to harm anything