### PR TITLE
Extract SessionRecorderNode to separate class

### DIFF
--- a/src/Scene/SessionRecorderNode.ts
+++ b/src/Scene/SessionRecorderNode.ts
@@ -1,3 +1,5 @@
+// maybe not the most elegant to import from here, but since they share the underlying worklet, the message types are the same
+import type { RecordingMessage } from '../Track/TrackRecorderNode'
 import { logger } from '../util/logger'
 import type { ExportWavWorkerEvent } from '../workers/export'
 
@@ -11,29 +13,6 @@ type RecordingProperties = {
   monitorInput?: boolean
   exportWorker: Worker
 }
-
-type MaxRecordingLengthReachedMessage = {
-  message: 'MAX_RECORDING_LENGTH_REACHED'
-}
-
-type ShareRecordingBufferMessage = {
-  message: 'SHARE_RECORDING_BUFFER'
-  channelsData: Array<Float32Array>
-  recordingLength: number
-  // this allows us to send data through the recorder in messages. Saves an extra ref or piece of state
-  forwardData: Record<string, any>
-}
-
-type UpdateWaveformMessage = {
-  message: 'UPDATE_WAVEFORM'
-  gain: number
-  samplesPerFrame: number
-}
-
-export type RecordingMessage =
-  | MaxRecordingLengthReachedMessage
-  | ShareRecordingBufferMessage
-  | UpdateWaveformMessage
 
 export class SessionRecorderNode extends AudioWorkletNode {
   numberOfChannels: number

--- a/src/Scene/SessionRecorderNode.ts
+++ b/src/Scene/SessionRecorderNode.ts
@@ -1,0 +1,107 @@
+import { logger } from '../util/logger'
+import type { ExportWavWorkerEvent } from '../workers/export'
+
+type RecordingProperties = {
+  numberOfChannels: number
+  sampleRate: number
+  maxRecordingSamples: number
+  /**
+   * default: false
+   */
+  monitorInput?: boolean
+  exportWorker: Worker
+}
+
+type MaxRecordingLengthReachedMessage = {
+  message: 'MAX_RECORDING_LENGTH_REACHED'
+}
+
+type ShareRecordingBufferMessage = {
+  message: 'SHARE_RECORDING_BUFFER'
+  channelsData: Array<Float32Array>
+  recordingLength: number
+  // this allows us to send data through the recorder in messages. Saves an extra ref or piece of state
+  forwardData: Record<string, any>
+}
+
+type UpdateWaveformMessage = {
+  message: 'UPDATE_WAVEFORM'
+  gain: number
+  samplesPerFrame: number
+}
+
+export type RecordingMessage =
+  | MaxRecordingLengthReachedMessage
+  | ShareRecordingBufferMessage
+  | UpdateWaveformMessage
+
+export class SessionRecorderNode extends AudioWorkletNode {
+  numberOfChannels: number
+  audioContext: AudioContext
+  exportWorker: Worker
+
+  constructor(
+    audioContext: AudioContext,
+    {
+      exportWorker,
+      ...processorOptions
+    }: RecordingProperties
+  ) {
+    super(audioContext, 'recorder', { processorOptions })
+    logger.debug({ processorOptions })
+
+    this.port.onmessage = (event) => this.onmessage(event.data)
+    this.destroy.bind(this)
+
+    this.audioContext = audioContext
+    this.numberOfChannels = processorOptions.numberOfChannels
+    this.exportWorker = exportWorker
+  }
+
+  /**
+   * Builds a callback that handles the messages from the recorder worker.
+   * The most important message to handle is SHARE_RECORDING_BUFFER,
+   * which indicates that the recording buffer is ready for playback.
+   */
+  onmessage(data: RecordingMessage) {
+    if (data.message === 'MAX_RECORDING_LENGTH_REACHED') {
+      // Not exactly sure what should happen in this case ¯\_(ツ)_/¯
+      alert(
+        "You recorded more than 500 seconds. That isn't allowed. Not sure why though, maybe it can record indefinitely?"
+      )
+      logger.error(data)
+    }
+
+    // See Track/index.tsx for detailed notes on the functionality here
+    if (data.message === 'SHARE_RECORDING_BUFFER') {
+      // this data is passed to the recorder worklet in `toggleRecording` function
+      const recordingDurationSeconds =
+        data.forwardData.recordingDurationSeconds
+      const recordingDurationSamples = Math.ceil(
+        this.audioContext.sampleRate * recordingDurationSeconds
+      )
+      logger.debug({
+        recordingDurationSamples,
+        recordingDurationSeconds,
+        'data.channelsData[0].length':
+          data.channelsData[0].length,
+      })
+
+      logger.debug(`Posting export message for scene performance`)
+      this.exportWorker.postMessage({
+        message: 'EXPORT_TO_WAV',
+        audioBufferLength: recordingDurationSamples,
+        numberOfChannels: this.numberOfChannels,
+        sampleRate: this.audioContext.sampleRate,
+        channelsData: data.channelsData.map((data) =>
+          data.slice(0, recordingDurationSamples)
+        ),
+      } as ExportWavWorkerEvent)
+    }
+  }
+
+  destroy() {
+    this.disconnect()
+    this.port.onmessage = null
+  }
+}

--- a/src/Scene/index.tsx
+++ b/src/Scene/index.tsx
@@ -5,9 +5,9 @@ import { useKeybindings } from '../hooks/use-keybindings'
 import { Plus } from '../icons/Plus'
 import { Record } from '../icons/Record'
 import { Track } from '../Track'
-import { RecordingMessage } from '../Track/RecorderNode'
 import { logger } from '../util/logger'
-import { ExportWavWorkerEvent, WavBlobControllerEvent } from '../workers/export'
+import { WavBlobControllerEvent } from '../workers/export'
+import { SessionRecorderNode } from './SessionRecorderNode'
 
 type Props = {
   clock: Worker
@@ -37,57 +37,14 @@ export const Scene: React.FC<Props> = ({
    * This way, the output from the GainNode is sent to the recorder worklet, and it all gets mixed into a single buffer.
    */
   const sessionWorklet = useMemo<AudioWorkletNode>(() => {
-    // for the bounced recording, we can assume we'll always use 2 channels
-    const numberOfChannels = 2
-
-    const worklet = new AudioWorkletNode(audioContext, 'recorder', {
-      processorOptions: {
-        numberOfChannels: 2,
-        sampleRate: audioContext.sampleRate,
-        // 500 seconds... ? ¯\_(ツ)_/¯
-        maxRecordingSamples: audioContext.sampleRate * 500,
-        latencySamples: 0,
-      },
+    return new SessionRecorderNode(audioContext, {
+      // for the bounced recording, we can assume we'll always use 2 channels
+      numberOfChannels: 2,
+      sampleRate: audioContext.sampleRate,
+      // 500 seconds... ? ¯\_(ツ)_/¯
+      maxRecordingSamples: audioContext.sampleRate * 500,
+      exportWorker,
     })
-
-    worklet.port.onmessage = (event: MessageEvent<RecordingMessage>) => {
-      if (event.data.message === 'MAX_RECORDING_LENGTH_REACHED') {
-        // Not exactly sure what should happen in this case ¯\_(ツ)_/¯
-        alert(
-          "You recorded more than 500 seconds. That isn't allowed. Not sure why though, maybe it can record indefinitely?"
-        )
-        logger.error(event.data)
-      }
-
-      // See Track/index.tsx for detailed notes on the functionality here
-      if (event.data.message === 'SHARE_RECORDING_BUFFER') {
-        // this data is passed to the recorder worklet in `toggleRecording` function
-        const recordingDurationSeconds =
-          event.data.forwardData.recordingDurationSeconds
-        const recordingDurationSamples = Math.ceil(
-          audioContext.sampleRate * recordingDurationSeconds
-        )
-        logger.debug({
-          recordingDurationSamples,
-          recordingDurationSeconds,
-          'event.data.channelsData[0].length':
-            event.data.channelsData[0].length,
-        })
-
-        logger.debug(`Posting export message for scene performance`)
-        exportWorker.postMessage({
-          message: 'EXPORT_TO_WAV',
-          audioBufferLength: recordingDurationSamples,
-          numberOfChannels: numberOfChannels,
-          sampleRate: audioContext.sampleRate,
-          channelsData: event.data.channelsData.map((data) =>
-            data.slice(0, recordingDurationSamples)
-          ),
-        } as ExportWavWorkerEvent)
-      }
-    }
-
-    return worklet
   }, [audioContext, exportWorker])
 
   /**

--- a/src/Track/TrackRecorderNode.ts
+++ b/src/Track/TrackRecorderNode.ts
@@ -40,7 +40,7 @@ export type RecordingMessage =
   | ShareRecordingBufferMessage
   | UpdateWaveformMessage
 
-export class RecorderNode extends AudioWorkletNode {
+export class TrackRecorderNode extends AudioWorkletNode {
   bpm: number
   measuresPerLoop: number
   beatsPerMeasure: number

--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -34,7 +34,7 @@ import type {
   WavBlobControllerEvent,
 } from '../workers/export'
 import { useKeybindings } from '../hooks/use-keybindings'
-import { RecorderNode } from './RecorderNode'
+import { TrackRecorderNode } from './TrackRecorderNode'
 
 type Props = {
   id: number
@@ -166,13 +166,13 @@ export const Track: React.FC<Props> = ({
    * Initialize the recorder worklet, and connect the audio graph for eventual playback.
    */
   const [recorderWorklet, mediaSource] = useMemo<
-    [RecorderNode, MediaStreamAudioSourceNode] | [null, null]
+    [TrackRecorderNode, MediaStreamAudioSourceNode] | [null, null]
   >(() => {
     if (!stream) {
       return [null, null]
     }
     const mediaSource = audioContext.createMediaStreamSource(stream)
-    const worklet = new RecorderNode(audioContext, {
+    const worklet = new TrackRecorderNode(audioContext, {
       numberOfChannels: mediaSource.channelCount,
       sampleRate: audioContext.sampleRate,
       // max recording length of 30 seconds. I think that should be sufficient for now?


### PR DESCRIPTION
Same as #42 but for the `SessionRecorderNode`, which is used in the `Scene` component.

Also renamed `RecorderNode` to `TrackRecorderNode` for extra clarity