### PR TITLE
Loop length calculations

### DIFF
--- a/src/Metronome/index.tsx
+++ b/src/Metronome/index.tsx
@@ -46,6 +46,17 @@ export const Metronome: React.FC<Props> = ({ clock }) => {
   const [gain, setGain] = useState(0.5)
   const [muted, setMuted] = useState(false)
   const toggleMuted = useCallback(() => setMuted((muted) => !muted), [])
+  // When in doubt... use dimensional analysis! 🙃 (not clear why the unicode rendering is so different in editor vs online)
+  //
+  //  60 seconds    beats       60 seconds    minute
+  // ———————————— ➗ —————   🟰  ——————————— 𝒙  ———————      =>
+  //   minute      minute        minute       beats
+  //
+  //   seconds    minutes   measures    beats        seconds
+  //  ————————— 𝒙 ———————— 𝒙 ———————— 𝒙 ————————  🟰 ——————————
+  //   minute     beat      loop       measure        loop
+  const loopLengthSeconds =
+    (60 / bpm) * measuresPerLoop * timeSignature.beatsPerMeasure
 
   /**
    * create 2 AudioBuffers with different frequencies,
@@ -193,12 +204,7 @@ export const Metronome: React.FC<Props> = ({ clock }) => {
           />
         </div>
       </div>
-      <Scene
-        clock={clock}
-        bpm={bpm}
-        measuresPerLoop={measuresPerLoop}
-        beatsPerMeasure={timeSignature.beatsPerMeasure}
-      />
+      <Scene clock={clock} loopLengthSeconds={loopLengthSeconds} />
     </>
   )
 }

--- a/src/Metronome/index.tsx
+++ b/src/Metronome/index.tsx
@@ -139,6 +139,7 @@ export const Metronome: React.FC<Props> = ({ clock }) => {
         bpm,
         beatsPerMeasure: timeSignature.beatsPerMeasure,
         measuresPerLoop,
+        loopLengthSeconds,
       } as ClockWorkerStartMessage)
       setPlaying(true)
     }
@@ -160,6 +161,7 @@ export const Metronome: React.FC<Props> = ({ clock }) => {
       bpm,
       beatsPerMeasure: timeSignature.beatsPerMeasure,
       measuresPerLoop,
+      loopLengthSeconds,
     } as ClockWorkerUpdateMessage)
   }, [bpm, timeSignature.beatsPerMeasure, measuresPerLoop, clock])
 

--- a/src/Scene/index.tsx
+++ b/src/Scene/index.tsx
@@ -11,17 +11,10 @@ import { SessionRecorderNode } from './SessionRecorderNode'
 
 type Props = {
   clock: Worker
-  bpm: number
-  measuresPerLoop: number
-  beatsPerMeasure: number
+  loopLengthSeconds: number
 }
 
-export const Scene: React.FC<Props> = ({
-  clock,
-  bpm,
-  measuresPerLoop,
-  beatsPerMeasure,
-}) => {
+export const Scene: React.FC<Props> = ({ clock, loopLengthSeconds }) => {
   const [tracks, setTracks] = useState([{ id: 1, selected: false }])
   const exportTarget = useMemo(() => new EventTarget(), [])
   const downloadLinkRef = useRef<HTMLAnchorElement>(null)
@@ -164,9 +157,7 @@ export const Scene: React.FC<Props> = ({
           clock={clock}
           exportTarget={exportTarget}
           sessionWorklet={sessionWorklet}
-          bpm={bpm}
-          measuresPerLoop={measuresPerLoop}
-          beatsPerMeasure={beatsPerMeasure}
+          loopLengthSeconds={loopLengthSeconds}
         />
       ))}
       <div className="my-8 flex justify-between items-end">

--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -254,10 +254,7 @@ export const Track: React.FC<Props> = ({
         // keep waveform worker updated to metronome settings
         waveformWorker.postMessage({
           message: 'UPDATE_METRONOME',
-          // TODO
-          beatsPerSecond: event.data.bpm / 60,
-          measuresPerLoop: event.data.measuresPerLoop,
-          beatsPerMeasure: event.data.beatsPerMeasure,
+          loopLengthSeconds: event.data.loopLengthSeconds,
         } as WaveformWorkerMetronomeMessage)
       }
     }

--- a/src/Track/index.tsx
+++ b/src/Track/index.tsx
@@ -44,9 +44,7 @@ type Props = {
   exportTarget: EventTarget
   index: number
   sessionWorklet: AudioWorkletNode
-  bpm: number
-  measuresPerLoop: number
-  beatsPerMeasure: number
+  loopLengthSeconds: number
 }
 
 export const Track: React.FC<Props> = ({
@@ -57,9 +55,7 @@ export const Track: React.FC<Props> = ({
   exportTarget,
   index,
   sessionWorklet,
-  bpm,
-  measuresPerLoop,
-  beatsPerMeasure,
+  loopLengthSeconds,
 }) => {
   const { audioContext } = useAudioContext()
   // stream is initialized in SelectInput
@@ -182,9 +178,7 @@ export const Track: React.FC<Props> = ({
         stream,
         audioContext
       ),
-      bpm,
-      measuresPerLoop,
-      beatsPerMeasure,
+      loopLengthSeconds,
       waveformWorker,
       onRecordingBuffer,
     })
@@ -200,9 +194,7 @@ export const Track: React.FC<Props> = ({
     onRecordingBuffer,
     waveformWorker,
     stream,
-    bpm,
-    beatsPerMeasure,
-    measuresPerLoop,
+    loopLengthSeconds,
   ])
 
   /**
@@ -262,6 +254,7 @@ export const Track: React.FC<Props> = ({
         // keep waveform worker updated to metronome settings
         waveformWorker.postMessage({
           message: 'UPDATE_METRONOME',
+          // TODO
           beatsPerSecond: event.data.bpm / 60,
           measuresPerLoop: event.data.measuresPerLoop,
           beatsPerMeasure: event.data.beatsPerMeasure,

--- a/src/workers/waveform.ts
+++ b/src/workers/waveform.ts
@@ -13,9 +13,7 @@ export type WaveformWorkerInitializeMessage = {
 
 export type WaveformWorkerMetronomeMessage = {
   message: 'UPDATE_METRONOME'
-  beatsPerSecond: number
-  measuresPerLoop: number
-  beatsPerMeasure: number
+  loopLengthSeconds: number
 }
 
 export type WaveformWorkerResetMessage = {
@@ -88,8 +86,7 @@ self.onmessage = (e: MessageEvent<WaveformWorkerMessage>) => {
     // This is all to get the number of frames per loop.
     // Each data point on the waveform corresponds to a frame (many samples).
     // To correctly position the point along the x axis, we need to know how many frames to expect for the whole loop.
-    const beatsPerLoop = e.data.beatsPerMeasure * e.data.measuresPerLoop
-    samplesPerLoop = (samplesPerSecond * beatsPerLoop) / e.data.beatsPerSecond
+    samplesPerLoop = samplesPerSecond * e.data.loopLengthSeconds
   }
 
   if (e.data.message === 'RESET_FRAMES') {


### PR DESCRIPTION
Pass around pre-calculated `loopLengthSeconds` instead of individual `bpm`, `measuresPerLoop`, and `beatsPerMeasure` values