### PR TITLE
Generate click track as buffer

### DIFF
--- a/src/workers/clock.ts
+++ b/src/workers/clock.ts
@@ -99,6 +99,7 @@ self.onmessage = (e: MessageEvent<ClockWorkerMessage>) => {
   } else if (e.data.message === 'UPDATE') {
     // only start if it was already running
     if (timeoutId) {
+      currentTick = -1
       clearInterval(timeoutId)
       start(e.data.bpm, e.data.beatsPerMeasure, e.data.measuresPerLoop, e.data.loopLengthSeconds)
     }


### PR DESCRIPTION
Rather than creating an audio buffer for each click, generate a full click track as an audio buffer for each loop, and just play that loop.

There is apparently a long-standing bug regarding pausing that I didn't realize, and it comes to light in an ugly way with this change: suspending and resuming the audioContext does not align with the clock 😱. That is, when the clock is stopped and started again, it will just resume clicking immediately when the button is clicked. However, the audio buffer will be stopped from mid-beat, which is hard to get right inside the clock.

Need to think more on this. It kind of indicates yet again that a setInterval is not the right way to schedule things -- probably should be using AudioContext. Need to think more on this before merging